### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -6,6 +6,7 @@
     "depends" : [ ],
     "description" : "A few math and Physics constants",
     "name" : "Math::Constants",
+    "license" : "GPL-3.0",
     "perl" : "6.*",
     "provides" : {
 	"Math::Constants" : "lib/Math/Constants.pm6"


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license