### PR TITLE
Added Avogadro's number and Alpha particle mass

### DIFF
--- a/lib/Math/Constants.pm6
+++ b/lib/Math/Constants.pm6
@@ -19,6 +19,8 @@ my constant planck-length is export = 1.616199e-35;
 my constant lp is export := planck-length;
 my constant planck-temperature is export = 1.416833e+32;
 my constant L is export = 6.022140857e23;
+my constant alpha-particle is export 6.644657230e-27
+my constant avogadro is 6.022148857e23
 
 # Electrical constants
 my constant fine-structure-constant is export = 0.0072973525664;

--- a/lib/Math/Constants.pm6
+++ b/lib/Math/Constants.pm6
@@ -20,11 +20,15 @@ my constant lp is export := planck-length;
 my constant planck-temperature is export = 1.416833e+32;
 my constant L is export = 6.022140857e23;
 
+
 # Electrical constants
 my constant fine-structure-constant is export = 0.0072973525664;
 my constant elementary-charge is export = 1.6021766208e-19;
 my constant vacuum-permittivity is export = 8.854187817e-12;
 my constant vacuum-permeability is export = 12.566370614359e-7;
+my constant magnetic-flux-quantum is export = 2.067833831e-15;
+my constant nuclear-magneton is export = 5.050783699e-27;
+
 
 #Greek letters when available
 my constant φ is export := phi;


### PR DESCRIPTION
# Pull request template for `Math::Constants`

Added Avogadro's number and Alpha particle mass

## What kind of constants are you adding and its origin

Avogadro's  number and alpha particle's mass are both physical constants.

## Check list

* [x] It's a well known constant and I have added a reference for it
* [ ] I have added a test and it works.
* [x] I'm using the usual naming and abbreviation conventions.
  
