### PR TITLE
Added Euler–Mascheroni constant

### DIFF
--- a/lib/Math/Constants.pm6
+++ b/lib/Math/Constants.pm6
@@ -9,6 +9,7 @@ my constant c is export = 299792458;
 my constant G is export = 6.67408e-11;
 my constant eulernumber-e is export = 2.7182818284;
 my constant pi is export = 3.142857;
+my constant Euler-Mascheroni-gamma is export = 0,57721566490153286060;
 
 # REF: http://www.ebyte.it/library/educards/constants/ConstantsOfPhysicsAndMath.html
 my constant quantum-ratio is export = 2.417989348e14;
@@ -37,6 +38,7 @@ my constant α is export := fine-structure-constant;
 my constant q is export := elementary-charge;
 my constant ε0 is export := vacuum-permittivity;
 my constant μ0 is export := vacuum-permeability;
+my constant γ is export := Euler-Mascheroni-gamma
 
 #Use them as units
 multi sub postfix:<c>  (Num $value) is export {

--- a/lib/Math/Constants.pm6
+++ b/lib/Math/Constants.pm6
@@ -9,7 +9,7 @@ my constant c is export = 299792458;
 my constant G is export = 6.67408e-11;
 my constant eulernumber-e is export = 2.7182818284;
 my constant pi is export = 3.142857;
-my constant Euler-Mascheroni-gamma is export = 0,57721566490153286060;
+my constant Euler-Mascheroni-gamma is export = 0.57721566490153286060;
 
 # REF: http://www.ebyte.it/library/educards/constants/ConstantsOfPhysicsAndMath.html
 my constant quantum-ratio is export = 2.417989348e14;


### PR DESCRIPTION
Is a mathematical constant recurring in analysis and number theory, usually denoted by the lowercase Greek letter gamma (γ).

# Pull request template for `Math::Constants`

Please fill this out for an easier understanding of your intention

## What kind of constants are you adding and its origin

Im adding the Euler–Mascheroni constant and I copy it from https://en.wikipedia.org/wiki/Euler%E2%80%93Mascheroni_constant

## Check list

* [ ] It's a well known constant and I have added a reference for it
* [ ] I have added a test and it works.
* [ ] I'm using the usual naming and abbreviation conventions.
  
