### PR TITLE
Added Faraday constant

### DIFF
--- a/lib/Math/Constants.pm6
+++ b/lib/Math/Constants.pm6
@@ -9,6 +9,7 @@ my constant c is export = 299792458;
 my constant G is export = 6.67408e-11;
 my constant eulernumber-e is export = 2.7182818284;
 my constant pi is export = 3.142857;
+my constant F is export = 96484.5561;
 
 # REF: http://www.ebyte.it/library/educards/constants/ConstantsOfPhysicsAndMath.html
 my constant quantum-ratio is export = 2.417989348e14;


### PR DESCRIPTION
Added the faraday constant seen here: https://quimica.laguia2000.com/conceptos-basicos/constante-de-faraday

# Pull request template for `Math::Constants`

Please fill this out for an easier understanding of your intention

## What kind of constants are you adding and its origin

the faraday constant used in physics and chemistry seen in https://quimica.laguia2000.com/conceptos-basicos/constante-de-faraday

## Check list

* [ ] It's a well known constant and I have added a reference for it
* [ ] I have added a test and it works.
* [ ] I'm using the usual naming and abbreviation conventions.
  
