### PR TITLE
 Added math constants (theoretical) #5

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,17 @@ as `plancks-h` or `ℎ` and `plancks-reduced-h` or `ℏ`.
 * [Golden ratio](https://en.wikipedia.org/wiki/Golden_ratio) as `phi`
   or φ.
 * Several electronic constants: [α](https://en.wikipedia.org/wiki/Fine-structure_constant) and the elementary charge and vacuum permittivity. 
+* [Feigenbaum constants](https://en.wikipedia.org/wiki/Feigenbaum_constants) as `alpha-feigenbaum-constant` and `delta-feigenbaum-constant`.
+* [Apéry's constant](https://en.wikipedia.org/wiki/Ap%C3%A9ry%27s_constant) as `apery-constant`.
+* [Conway's constant](https://en.wikipedia.org/wiki/Look-and-say_sequence#Growth_in_length) as `conway-constant` and `λ`.
+* [Khinchin's constant](https://en.wikipedia.org/wiki/Khinchin%27s_constant) as `khinchin-constant` and `k0`.
+* [Glaisher–Kinkelin constant](https://en.wikipedia.org/wiki/Glaisher%E2%80%93Kinkelin_constant) as `glaisher-kinkelin-constant` and `A`.
+* [Golomb–Dickman constant](https://en.wikipedia.org/wiki/Golomb%E2%80%93Dickman_constant) as `golomb-dickman-constant`. 
+* [Catalan's constant](https://en.wikipedia.org/wiki/Catalan%27s_constant) as `catalan-constant`. 
+* [Mill's constant](https://en.wikipedia.org/wiki/Mills%27_constant) as `mill-constant`. 
+* [Gauss's constant](https://en.wikipedia.org/wiki/Gauss%27s_constant) as `gauss-constant`. 
+* [Euler–Mascheroni constant](https://en.wikipedia.org/wiki/Euler%E2%80%93Mascheroni_constant) as `euler-mascheroni-gamma` and `γ`. 
+* [Sierpiński's constant](https://en.wikipedia.org/wiki/Sierpi%C5%84ski%27s_constant) as `sierpinski-gamma` and `k`. 
 
 Issues and suggestions
 ======================

--- a/lib/Math/Constants.pm6
+++ b/lib/Math/Constants.pm6
@@ -32,6 +32,21 @@ my constant boltzmann-constant is export = 8.617343e-5; #eV i.e in electronvolts
 my constant eV is export = 1.60217653e-19;
 my constant vacuum-permeability is export = 12.566370614359e-7;
 
+# (Strictly) Mathematical constants
+# REF: https://en.wikipedia.org/wiki/Mathematical_constant
+my constant alpha-feigenbaum-constant is export =  2.502907875095892822283e0;
+my constant delta-feigenbaum-constant is export = 4.669201609102990e0;
+my constant apery-constant is export = 1.2020569031595942853997381e0;
+my constant conway-constant is export = 1.303577269034e0;
+my constant khinchin-constant is export = 2.6854520010e0;
+my constant glaisher-kinkelin-constant is export = 1.2824271291e0;
+my constant golomb-dickman-constant is export = 0.62432998854355e0;
+my constant catalan-constant is export = 0.915965594177219015054603514e0;
+my constant mill-constant is export = 1.3063778838630806904686144e0;
+my constant gauss-constant is export = 0.8346268e0;
+my constant euler-mascheroni-gamma is export = 0.57721566490153286060e0;
+my constant sierpinski-gamma is export = 2.5849817595e0;
+
 #Greek letters when available
 my constant φ is export := phi;
 my constant ℎ is export := plancks-h;

--- a/lib/Math/Constants.pm6
+++ b/lib/Math/Constants.pm6
@@ -56,6 +56,15 @@ my constant q is export := elementary-charge;
 my constant ε0 is export := vacuum-permittivity;
 my constant μ0 is export := vacuum-permeability;
 
+my constant α is export := alpha-feigenbaum-constant;
+my constant δ is export := delta-feigenbaum-constant;
+my constant λ is export := conway-constant;
+my constant k0 is export := khinchin-constant;
+my constant A is export := glaisher-kinkelin-constant; 
+my constant G is export := catalan-constant; 
+my constant γ is export := euler-mascheroni-gamma; 
+my constant k is export := sierpinski-gamma; 
+
 #Use them as units
 multi sub postfix:<c>  (Num $value) is export {
     return c*$value;

--- a/lib/Math/Constants.pm6
+++ b/lib/Math/Constants.pm6
@@ -55,13 +55,10 @@ my constant α is export := fine-structure-constant;
 my constant q is export := elementary-charge;
 my constant ε0 is export := vacuum-permittivity;
 my constant μ0 is export := vacuum-permeability;
-
-my constant α is export := alpha-feigenbaum-constant;
 my constant δ is export := delta-feigenbaum-constant;
 my constant λ is export := conway-constant;
 my constant k0 is export := khinchin-constant;
 my constant A is export := glaisher-kinkelin-constant; 
-my constant G is export := catalan-constant; 
 my constant γ is export := euler-mascheroni-gamma; 
 my constant k is export := sierpinski-gamma; 
 

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -3,7 +3,7 @@ use Test;
 use lib ('../lib','lib');
 use Math::Constants;
 
-my @constants-names = <G phi plancks-h plancks-reduced-h elementary-charge vacuum-permittivity>;
+my @constants-names = <G phi plancks-h plancks-reduced-h elementary-charge vacuum-permittivity alpha-feigenbaum-constant delta-feigenbaum-constant apery-constant conway-constant khinchin-constant glaisher-kinkelin-constant golomb-dickman-constant catalan-constant mill-constant gauss-constant euler-mascheroni-gamma sierpinski-gamma>;
 my @constants;
 @constants-names ==> map  { EVAL $_  }  ==> @constants;
 
@@ -21,3 +21,5 @@ is-approx L, 6.022140857e23, "Avogadro's number";
 is-approx 0.1c, c/10, "Speed of light as unit";
 
 done-testing;
+
+


### PR DESCRIPTION
# Pull request template for `Math::Constants`
Added some math constants to the module. I added the constants to the file, test for them and update the readme with the additions plus their link to wikipedia.  I Hope the tests are alright (they work) but tell me otherwise and I will change them (first time doing them).

## What kind of constants are you adding and its origin
* [Feigenbaum constants](https://en.wikipedia.org/wiki/Feigenbaum_constants) as `alpha-feigenbaum-constant` and `delta-feigenbaum-constant`.
* [Apéry's constant](https://en.wikipedia.org/wiki/Ap%C3%A9ry%27s_constant) as `apery-constant`.
* [Conway's constant](https://en.wikipedia.org/wiki/Look-and-say_sequence#Growth_in_length) as `conway-constant` and `λ`.
* [Khinchin's constant](https://en.wikipedia.org/wiki/Khinchin%27s_constant) as `khinchin-constant` and `k0`.
* [Glaisher–Kinkelin constant](https://en.wikipedia.org/wiki/Glaisher%E2%80%93Kinkelin_constant) as `glaisher-kinkelin-constant` and `A`.
* [Golomb–Dickman constant](https://en.wikipedia.org/wiki/Golomb%E2%80%93Dickman_constant) as `golomb-dickman-constant`. 
* [Catalan's constant](https://en.wikipedia.org/wiki/Catalan%27s_constant) as `catalan-constant`. 
* [Mill's constant](https://en.wikipedia.org/wiki/Mills%27_constant) as `mill-constant`. 
* [Gauss's constant](https://en.wikipedia.org/wiki/Gauss%27s_constant) as `gauss-constant`. 
* [Euler–Mascheroni constant](https://en.wikipedia.org/wiki/Euler%E2%80%93Mascheroni_constant) as `euler-mascheroni-gamma` and `γ`. 
* [Sierpiński's constant](https://en.wikipedia.org/wiki/Sierpi%C5%84ski%27s_constant) as `sierpinski-gamma` and `k`.

## Check list

* [x] It's a well known constant and I have added a reference for it
* [x] I have added a test and it works.
* [x] I'm using the usual naming and abbreviation conventions.
  
