### PR TITLE
Adds new constants

### DIFF
--- a/lib/Math/Constants.pm6
+++ b/lib/Math/Constants.pm6
@@ -13,9 +13,9 @@ my constant pi is export = 3.142857;
 my constant gas-constant = 8.3144598;
 my constant F is export = 96484.5561;
 
-my constant electron-mass = 9.10938356e-31;
-my constant proton-mass = 1.6726219e-27;
-my constant neutron-mass = 1.674929e-27;
+my constant electron-mass is export = 9.10938356e-31;
+my constant proton-mass is export = 1.6726219e-27;
+my constant neutron-mass is export = 1.674929e-27;
 
 # REF: http://www.ebyte.it/library/educards/constants/ConstantsOfPhysicsAndMath.html
 my constant quantum-ratio is export = 2.417989348e14;
@@ -81,7 +81,7 @@ multi sub postfix:<c>  (Rat $value) is export {
     return c*$value;
 }
 
-multi sub postfix:<g>  (Num $value) is export {
+multi sub postfix:<g>  (Rat $value) is export {
     return g*$value;
 }
 

--- a/lib/Math/Constants.pm6
+++ b/lib/Math/Constants.pm6
@@ -6,12 +6,16 @@ my constant phi is export = 1.61803398874989e0;
 my constant plancks-h is export = 6.626_070_040e-34;
 my constant plancks-reduced-h is export = 1.054_571_800e-34;
 my constant c is export = 299792458;
+my constant g is export = 9.80665;
 my constant G is export = 6.67408e-11;
 my constant eulernumber-e is export = 2.7182818284;
 my constant pi is export = 3.142857;
 my constant gas-constant = 8.3144598;
 my constant F is export = 96484.5561;
 
+my constant electron-mass = 9.10938356e-31;
+my constant proton-mass = 1.6726219e-27;
+my constant neutron-mass = 1.674929e-27;
 
 # REF: http://www.ebyte.it/library/educards/constants/ConstantsOfPhysicsAndMath.html
 my constant quantum-ratio is export = 2.417989348e14;
@@ -60,17 +64,25 @@ my constant μ0 is export := vacuum-permeability;
 my constant δ is export := delta-feigenbaum-constant;
 my constant λ is export := conway-constant;
 my constant k0 is export := khinchin-constant;
-my constant A is export := glaisher-kinkelin-constant; 
-my constant γ is export := euler-mascheroni-gamma; 
-my constant k is export := sierpinski-gamma; 
+my constant A is export := glaisher-kinkelin-constant;
+my constant γ is export := euler-mascheroni-gamma;
+my constant k is export := sierpinski-gamma;
 
 #Use them as units
 multi sub postfix:<c>  (Num $value) is export {
     return c*$value;
 }
 
+multi sub postfix:<g>  (Num $value) is export {
+    return g*$value;
+}
+
 multi sub postfix:<c>  (Rat $value) is export {
     return c*$value;
+}
+
+multi sub postfix:<g>  (Num $value) is export {
+    return g*$value;
 }
 
 =begin pod

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -3,15 +3,16 @@ use Test;
 use lib ('../lib','lib');
 use Math::Constants;
 
-my @constants-names = <G phi plancks-h plancks-reduced-h elementary-charge vacuum-permittivity alpha-feigenbaum-constant delta-feigenbaum-constant apery-constant conway-constant khinchin-constant glaisher-kinkelin-constant golomb-dickman-constant catalan-constant mill-constant gauss-constant euler-mascheroni-gamma sierpinski-gamma>;
+my @constants-names = <G phi plancks-h plancks-reduced-h elementary-charge vacuum-permittivity alpha-feigenbaum-constant delta-feigenbaum-constant apery-constant conway-constant khinchin-constant glaisher-kinkelin-constant golomb-dickman-constant catalan-constant mill-constant gauss-constant euler-mascheroni-gamma sierpinski-gamma electron-mass proton-mass neutron-mass>;
 my @constants;
 @constants-names ==> map  { EVAL $_  }  ==> @constants;
 
-@constants.map( { is .WHAT, (Num), "Type OK"} ); 
+@constants.map( { is .WHAT, (Num), "Type OK"} );
 
 is c.WHAT, (Int), "c is OK";
+is g.WHAT, (Rat), "g is OK";
 is α.WHAT, (Rat), "e is OK";
-   
+
 is-approx ℎ/(2*π), ℏ, "Planck's constants";
 is-approx φ, (1 + sqrt(5))/2, "Golden ratio";
 is-approx α, 0.00729735256, "Fine structure";
@@ -20,6 +21,7 @@ is-approx L, 6.022140857e23, "Avogadro's number";
 
 is-approx 0.1c, c/10, "Speed of light as unit";
 
+is-approx 0.1g, g/10, "Standard gravity";
+
+
 done-testing;
-
-


### PR DESCRIPTION
# Pull request template for `Math::Constants`

Adding new constants.

## What kind of constants are you adding and its origin

Adds new constants for standard gravity(g), electron mass, proton mass and neutron mass. Sourced from Wikipedia:

g: https://en.wikipedia.org/wiki/Standard_gravity
electron-mass: https://en.wikipedia.org/wiki/Electron_rest_mass
proton-mass: https://en.wikipedia.org/wiki/Proton
neutron-mass: https://en.wikipedia.org/wiki/Neutron

## Check list

* [x ] It's a well known constant and I have added a reference for it
* [x] I have added a test and it works.
* [x] I'm using the usual naming and abbreviation conventions.
  
